### PR TITLE
Test that dotnet-runtime can return runtimes available (v2)

### DIFF
--- a/recipe/build-aspnetcore.sh
+++ b/recipe/build-aspnetcore.sh
@@ -3,7 +3,7 @@ set -eox pipefail
 
 PREFIX=$(echo "${PREFIX}" | tr '\\' '/')
 
-if [[ "${build_platform}" == "win-64" ]]; then
+if [[ "${target_platform}" == "win-64" ]]; then
     DOTNET_ROOT="${PREFIX}/dotnet"
 else
     DOTNET_ROOT="${PREFIX}/lib/dotnet"

--- a/recipe/build-desktop.sh
+++ b/recipe/build-desktop.sh
@@ -3,7 +3,7 @@ set -eox pipefail
 
 PREFIX=$(echo "${PREFIX}" | tr '\\' '/')
 
-if [[ "${build_platform}" == "win-64" ]]; then
+if [[ "${target_platform}" == "win-64" ]]; then
     DOTNET_ROOT="${PREFIX}/dotnet"
 else
     DOTNET_ROOT="${PREFIX}/lib/dotnet"

--- a/recipe/build-runtime.sh
+++ b/recipe/build-runtime.sh
@@ -3,7 +3,7 @@ set -eox pipefail
 
 PREFIX=$(echo "${PREFIX}" | tr '\\' '/')
 
-if [[ "${build_platform}" == "win-64" ]]; then
+if [[ "${target_platform}" == "win-64" ]]; then
     DOTNET_ROOT="${PREFIX}/dotnet"
 else
     DOTNET_ROOT="${PREFIX}/lib/dotnet"
@@ -18,5 +18,5 @@ cp -r ./dotnet/host/ "${DOTNET_ROOT}/host/"
 
 mkdir -p "${PREFIX}/etc/conda/activate.d"
 mkdir -p "${PREFIX}/etc/conda/deactivate.d"
-cp -r "${RECIPE_DIR}/activate.d/" "${PREFIX}/etc/conda/"
-cp -r "${RECIPE_DIR}/deactivate.d/" "${PREFIX}/etc/conda/"
+cp -r "${RECIPE_DIR}/activate.d/." "${PREFIX}/etc/conda/activate.d/"
+cp -r "${RECIPE_DIR}/deactivate.d/." "${PREFIX}/etc/conda/deactivate.d/"

--- a/recipe/build-sdk.sh
+++ b/recipe/build-sdk.sh
@@ -3,12 +3,10 @@ set -eox pipefail
 
 PREFIX=$(echo "${PREFIX}" | tr '\\' '/')
 
-if [[ "${build_platform}" == "win-64" ]]; then
+if [[ "${target_platform}" == "win-64" ]]; then
     DOTNET_ROOT="${PREFIX}/dotnet"
 else
     DOTNET_ROOT="${PREFIX}/lib/dotnet"
-    cp $RECIPE_DIR/dotnet.bash $PREFIX/bin/dotnet
-    chmod +x $PREFIX/bin/dotnet
 fi
 
 mkdir -p "${DOTNET_ROOT}"

--- a/recipe/dotnet.bash
+++ b/recipe/dotnet.bash
@@ -1,2 +1,0 @@
-#!/bin/bash
-$DOTNET_ROOT/dotnet $@

--- a/recipe/dotnet.cmd
+++ b/recipe/dotnet.cmd
@@ -1,1 +1,0 @@
-@"%~dp0..\dotnet\dotnet.exe" %*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
   folder: dotnet
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: dotnet
@@ -28,7 +28,6 @@ outputs:
       run:
         - {{ pin_subpackage('dotnet-runtime', exact=True) }}
         - {{ pin_subpackage('dotnet-aspnetcore', exact=True) }}
-#        - {{ pin_subpackage('dotnet-desktop', exact=True) }}  # [win]
         - {{ pin_subpackage('dotnet-sdk', exact=True) }}
     test:
       commands:
@@ -55,8 +54,7 @@ outputs:
         - __glibc >=2.17            # [linux64]
     test:
       commands:
-        - test -f $PREFIX/lib/dotnet/dotnet                 # [not win]
-        - if not exist %PREFIX%\\dotnet\\dotnet.exe exit 1  # [win]
+        - dotnet --list-runtimes
     about:
       home: https://github.com/dotnet/runtime
       license: MIT
@@ -127,25 +125,6 @@ outputs:
       summary: |
         .NET Core is a free and open-source managed computer software
         framework for the Windows, Linux, and macOS operating systems.
-
-#  - name: dotnet-desktop                                                              # [win]
-#    version: {{ runtime_version }}                                                    # [win]
-#    script: build-desktop.bat                                                         # [win]
-#    requirements:                                                                     # [win]
-#      build:                                                                          # [win]
-#        - posix                                                                       # [win]
-#      run:                                                                            # [win]
-#        - dotnet-runtime ={{ runtime_version }}                                       # [win]
-#    test:                                                                             # [win]
-#      commands:                                                                       # [win]
-#        - if not exist %PREFIX%\\dotnet\\shared\\Microsoft.WindowsDesktop.App exit 1  # [win]
-#    about:                                                                            # [win]
-#      home: https://github.com/dotnet/desktop                                         # [win]
-#      license: MIT                                                                    # [win]
-#      license_file: dotnet/LICENSE.txt                                                # [win]
-#      summary: |                                                                      # [win]
-#        .NET Core is a free and open-source managed computer software
-#        framework for the Windows, Linux, and macOS operating systems.
 
 about:
   home: https://github.com/dotnet/core


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

List of changes:

- Changed build_platform to target_platform because it seems more precise. Mentioned here (conda-forge/staged-recipes#14623 (comment)).
- Specify DOTNET_ROOT in the small executable for macOS/Linux. Right now, it's doesn't appear to be set. Not sure how to fix that.
- Test dotnet --list-runtimes with dotnet-runtime, which is closer to its function