### PR TITLE
Declare glibc 2.28 on linux: .NET 10 raised its floor

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,7 @@
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,11 @@
 c_stdlib_version:
   # Needed for CryptoKit
   - "11.3"  # [osx and x86_64]
+  # .NET 10 raised its glibc floor. Microsoft's prebuilt runtime requires
+  # glibc 2.27 (libclrjit.so, libcoreclr.so, libclrgcexp.so) on both linux-x64
+  # and linux-arm64, where 8.0 and 9.0 needed only 2.17. Verified with
+  # `check-glibc` from cf-nvidia-tools. Without this the packages declare
+  # `__glibc >=2.17` and install on hosts where the runtime cannot load.
+  # 2.28 rather than 2.27 because conda-forge ships no sysroot 2.27; it
+  # over-restricts by one release (glibc 2.27 is Ubuntu 18.04, EOL).
+  - "2.28"  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
   folder: dotnet
 
 build:
-  number: 0
+  number: 1
   binary_relocation: False  # [osx]
 
 outputs:


### PR DESCRIPTION
🤖 Follows up @dhirschfeld's note on #55 pointing at [`check-glibc`](https://github.com/conda-forge/cf-nvidia-tools-feedstock/blob/main/recipe/bin/check-glibc). Running it found that this recipe under-declares its glibc requirement on Linux.

## The problem

Microsoft raised .NET's glibc floor at **.NET 10**. The recipe didn't follow, so the published packages advertise `__glibc >=2.17,<3.0.a0` while the runtime actually needs 2.27 — they install on hosts where the runtime then fails to load.

`check-glibc` against Microsoft's runtime tarballs:

| line | linux-x64 | linux-arm64 | recipe declares | |
|---|---|---|---|---|
| 8.0 / rt 8.0.29 | 2.17 | 2.17 | 2.17 | ✅ |
| 9.0 / rt 9.0.18 | 2.17 | 2.17 | 2.17 | ✅ |
| **10.0 / rt 10.0.10** | **2.27** | **2.27** | 2.17 | ❌ |
| 11.0 preview.6 | 2.27 | 2.27 | 2.17 | ❌ (will inherit) |

Confirmed on the channel — both `dotnet-runtime 10.0.0` and `10.0.10` carry `__glibc >=2.17,<3.0.a0`.

The floor comes from `libclrjit.so`, `libcoreclr.so` and `libclrgcexp.so`. Worth noting only **`dotnet-runtime`** ships native code (13 `.so` files); the aspnetcore shared framework and the sdk tree ship none, so `dotnet-runtime` is where the constraint lives — and it already carries `{{ stdlib('c') }}`, so unlike #111 the pin is in the right *place*, the value was just stale.

## The change

`c_stdlib_version: "2.28"  # [linux]`, plus a build number bump.

2.28 rather than 2.27 because conda-forge provides no sysroot 2.27 (2.12, 2.17, 2.28, 2.34, 2.39). That over-restricts by exactly one glibc release — 2.27 is Ubuntu 18.04, past EOL — which seemed better than leaving the declaration wrong.

Nothing is compiled here, so this is a pure metadata correction with no build risk.

## Scope

**`v8` and `v9` are deliberately untouched.** They declare 2.17 and genuinely require 2.17; raising them would drop CentOS 7-era users for no reason. This is a .NET 10 change, not a longstanding recipe defect.

Realistically the affected window (glibc 2.17–2.26: CentOS 7, Debian 9, Ubuntu 16.04) is entirely EOL, so I doubt anyone is hitting this today. Fixing it because the declaration is simply false, and because the failure mode — a load-time crash with no useful diagnostic — is one this feedstock has already lost a lot of time to.

Going forward I'll have the auto-bump tooling from #55 compare the measured floor against the declared one on every bump and open an issue rather than a silent PR when it moves, since this drifted once already without anyone noticing.

@conda-forge-admin, please rerender
