### PR TITLE
Assert the glibc floor in CI with check-glibc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
   folder: dotnet
 
 build:
-  number: 1
+  number: 2
   binary_relocation: False  # [osx]
 
 outputs:
@@ -78,8 +78,26 @@ outputs:
         # "No usable version of libssl was found".
         - openssl <4  # [aarch64]
     test:
+      requires:
+        - cf-nvidia-tools 1.*  # [linux]
       commands:
         - dotnet --list-runtimes
+        # Assert the shipped binaries actually meet the glibc floor this recipe
+        # declares, rather than trusting that they still do. .NET 10 raised its
+        # requirement from 2.17 to 2.27 while the recipe went on declaring 2.17,
+        # so every 10.0.x package advertised `__glibc >=2.17` and installed on
+        # hosts where the runtime cannot load. A version bump touches only
+        # versions and hashes, so nothing caught it for the whole line.
+        #
+        # This output is the only one that needs it: aspnetcore's shared
+        # framework and the sdk tree ship no native objects at all.
+        #
+        # The count guard is NOT redundant. check-glibc skips paths that do not
+        # exist, so if this layout ever changes the file list comes back empty
+        # and the check exits 0 -- a silently vacuous pass, which is worse than
+        # no check. Verified directly: an empty file list returns success.
+        - test $(find $PREFIX/lib/dotnet -name '*.so' | wc -l) -ge 10  # [linux]
+        - c_stdlib_version={{ c_stdlib_version }} check-glibc $PREFIX/lib/dotnet/dotnet $(find $PREFIX/lib/dotnet -name '*.so')  # [linux]
     about:
       home: https://github.com/dotnet/runtime
       license: MIT


### PR DESCRIPTION
🤖 Follows @dhirschfeld's suggestion on #120: put [`check-glibc`](https://github.com/conda-forge/cf-nvidia-tools-feedstock/blob/main/recipe/bin/check-glibc) in this feedstock's own CI so future bumps get caught here, rather than relying on external tooling to notice after publication.

> I think, as shown in the `copilot-cli` PR, that you can use `check-glibc` in CI so that future bumps will get caught.

Agreed, and it's the stronger guard — it blocks the merge instead of reporting afterwards, and it covers every PR by anyone rather than only what a bot proposes.

## Verified against the real published package

Unpacked `dotnet-runtime-10.0.10-hb700be7_0.conda` from the channel and ran `check-glibc` over exactly the file list the test uses:

| declared floor | result |
|---|---|
| `2.17` — what the recipe said before #120 | **FAIL**, exit 1 — `binary glibc 2.27.0 <= recipe glibc 2.17 … The binary is not compatible with the recipe's glibc pinning.` |
| `2.28` — what `main` declares now | **PASS**, exit 0, 15 objects checked |

So it would have caught the bug #120 fixed, and passes against the floor now on `main`.

## Details worth flagging

**The file-count guard is not decoration.** `check-glibc` skips paths that don't exist, so an empty file list exits **0** — I verified that directly. Without the guard, a layout change silently turns this into a vacuous pass. That matters here specifically: #111 was an osx bug that survived 15 months because `dotnet --list-runtimes` passed in CI while the package was killed on a real install. A check that can quietly stop checking is worse than no check.

**Only `dotnet-runtime` needs it.** It ships all 15 native objects — the host, `libhostfxr.so`, and 13 under `shared/Microsoft.NETCore.App`. The aspnetcore shared framework and the sdk tree ship zero `.so` files.

**`find` rather than a glob on `shared/`**, because `libhostfxr.so` lives outside it; the host binary is passed explicitly.

**Gated to `# [linux]`.** On osx, `c_stdlib_version` renders as the CryptoKit `11.3` pin and `check-glibc` finds no GLIBC symbols in Mach-O, so it passes *vacuously* rather than failing — noise that could later be mistaken for coverage. (The `copilot-cli` recipe uses `if: unix`; on this recipe I'd rather it not run at all where it can't mean anything.)

**Rendering checked on all four platforms:** `c_stdlib_version` interpolates to `2.28` on `linux-64` and `linux-aarch64` with `cf-nvidia-tools` in `test: requires`, and both commands are absent on `osx-64` and `win-64`. `cf-nvidia-tools` is `noarch`, and `conda-forge.yml` sets `test: native_and_emulated`, so the cross-compiled `linux_aarch64` leg actually runs this under emulation rather than skipping it.

## Not covered here

`check-glibc` doesn't look at openssl, and the `openssl <4` pin has the same drift problem in both directions — .NET 11 preview.6 adds `libssl.so.4`, so that pin will become over-restrictive when 11 ships, and openssl is currently undeclared on `linux-x64` entirely. I'm tracking that out-of-band for now rather than growing this PR.

Happy to add the same test to `v8`/`v9` if useful — both declare 2.17 and genuinely require 2.17, so it would pass and guard future patch bumps on those lines.
